### PR TITLE
Fix problem with Path core object not being present with file handler

### DIFF
--- a/csv2cash/main.py
+++ b/csv2cash/main.py
@@ -87,7 +87,7 @@ def get_translation(path_to_translationJSON):
     """Returns dictionary with translations.json data"""
 
     logger.debug(f'Function start arguments: {locals()}')
-    with path_to_translationJSON.open() as translationjson:
+    with Path(path_to_translationJSON).open() as translationjson:
         return (jsonload(translationjson))
 
 

--- a/csv2cash/main.py
+++ b/csv2cash/main.py
@@ -390,7 +390,7 @@ def import2cash(transactions_compiled, path_to_Book):
     logger.info(f'Function start')
     logger.info(f'Length of transactions_compiled: {len(transactions_compiled.index)}')
 
-    book = piecash.open_book(path_to_Book.as_posix(), readonly=False)
+    book = piecash.open_book(Path(path_to_Book).as_posix(), readonly=False, open_if_lock=True)
 
     # if the GNUCash Book has one currency, use that currency
     if len(book.commodities) == 1:


### PR DESCRIPTION
These additions address two locations where `Path` was required in order to get the examples run. More may be needed with other modules.